### PR TITLE
copy to authorized keys instead of moving file

### DIFF
--- a/dockers/app/certs.sh
+++ b/dockers/app/certs.sh
@@ -6,7 +6,7 @@ then
 else
 	echo "$public_key not found, generating new ones."
 	cat /dev/zero | ssh-keygen -q -N ""
-	mv /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys 
+	cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys 
 
     #ssh-keyscan isard-hypervisor > /tmp/known_hosts
     #DIFF=$(diff /root/.ssh/know_hosts /tmp/known_hosts) 


### PR DESCRIPTION
This hotfix allows adding other hypervisors easier.