### PR TITLE
bugs creating template and download media

### DIFF
--- a/src/engine/services/lib/download.py
+++ b/src/engine/services/lib/download.py
@@ -7,7 +7,7 @@ def test_url_for_download(url,url_download_insecure_ssl=True,
     to download media, domains..."""
     try:
         response = requests.head(url,
-                                 allow_redirects=False,
+                                 allow_redirects=True,
                                  verify=url_download_insecure_ssl,
                                  timeout=timeout_time_limit,
                                  headers=dict_header)

--- a/src/engine/services/lib/qcow.py
+++ b/src/engine/services/lib/qcow.py
@@ -351,7 +351,16 @@ def verify_output_cmds1_template_from_domain(cmds_done, path_domain_disk, path_t
         log.debug('cmd: {}, out: {}, err: {}'.format(d['cmd'], d['out'], d['err']))
         error_severity = 'Hard'
     elif error_severity != 'Hard':
-        df_bytes = int(d['out'].splitlines()[-1].split()[3]) * 1024
+        try:
+            df_bytes = int(d['out'].splitlines()[-1].split()[3]) * 1024
+        except:
+            #if mount point is too large df split output in two lines
+            try:
+                df_bytes = int(d['out'].splitlines()[-1].split()[2]) * 1024
+            except:
+                log.info('When try to know disk free space previous to create template output is not standard')
+                log.debug('cmd: {}, out: {}, err: {}'.format(d['cmd'], d['out'], d['err']))
+                df_bytes = 999999999
         log.debug('disk free for create template from domain {}: {}'.format(id_domain, size_format(df_bytes)))
 
     d = [a for a in cmds_done if a['title'] == 'size_template_disk'][0]

--- a/src/webapp/lib/isardSocketio.py
+++ b/src/webapp/lib/isardSocketio.py
@@ -186,8 +186,8 @@ class MediaThread(threading.Thread):
 
     def run(self):
         with app.app_context():
-            for c in r.table('domains').get_all(r.args(['Downloading','Downloaded']),index='status').pluck('id','name','description','icon','progress','status','user').merge({'table':'domains'}).changes(include_initial=False).union(
-                    r.table('media').get_all(r.args(['DownloadStarting','Downloading','Downloaded']),index='status').merge({'table':'media'}).changes(include_initial=False)).run(db.conn):
+            for c in r.table('domains').get_all(r.args(['Downloaded', 'DownloadFailed','DownloadStarting', 'Downloading', 'DownloadAborting','ResetDownloading']),index='status').pluck('id','name','description','icon','progress','status','user').merge({'table':'domains'}).changes(include_initial=False).union(
+                    r.table('media').get_all(r.args(['Deleting', 'Deleted', 'Downloaded', 'DownloadFailed', 'DownloadStarting', 'Downloading', 'Download', 'DownloadAborting','ResetDownloading']),index='status').merge({'table':'media'}).changes(include_initial=False)).run(db.conn):
                 if self.stop==True: break
                 try:
                     if c['new_val'] is None:


### PR DESCRIPTION
When creating a template df command is launched to know free space. This command had two lines of output if the device of the mount point is too large.
When adding media like an iso from web server, if the URL failed these media disappear from the list.
Redirect testing URL is activated