### PR TITLE
Fixed minimum template name length

### DIFF
--- a/src/webapp/templates/pages/desktops_modals.html
+++ b/src/webapp/templates/pages/desktops_modals.html
@@ -234,7 +234,7 @@
                         <label class="control-label col-md-3 col-sm-3 col-xs-12" for="name">Template name <span class="required">*</span>
                         </label>
                         <div class="col-md-6 col-sm-6 col-xs-12">
-                           <input id="name" class="form-control col-md-7 col-xs-12 template-name" data-validate-length-range="4,40" name="name" placeholder="New desktop name" required="required" type="text">
+                            <input id="name" class="form-control template-name" maxlength="40" pattern="[-_àèìòùáéíóúñçÀÈÌÒÙÁÉÍÓÚÑÇ .a-zA-Z0-9]+$" data-parsley-length="[4, 40]" name="name" placeholder="New template name" data-parsley-trigger="change" required type="text">
                         </div>
                      </div>
                      <div class="item form-group">


### PR DESCRIPTION
Fixed minimal length of 4 characters for new templates. Fixes #86 