### PR TITLE
Fixed remote-hyper and port

### DIFF
--- a/dockers/app/certs.sh
+++ b/dockers/app/certs.sh
@@ -31,7 +31,7 @@ done
 
 if [[ "$i" -ne '25' ]]; then
   echo "Adding isard-hypervisor keys"
-  ssh-keyscan -T 10 isard-hypervisor > /root/.ssh/known_hosts
+  ssh-keyscan -T 10 isard-hypervisor >> /root/.ssh/known_hosts
 else
   echo "Assuming that there is no isard-hypervisor available"
 fi 

--- a/dockers/app/certs.sh
+++ b/dockers/app/certs.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+### If no id_rsa.pub key yet, create new one
+
+auth_keys="/root/.ssh/id_rsa.pub"
+if [ -f "$auth_keys" ]
+then
+    echo "$auth_keys found, so not generating new ones."
+else
+    echo "$auth_keys not found, generating new ones."
+    cat /dev/zero | ssh-keygen -q -N ""
+    #Copy new host key to authorized_keys (so isard-hypervisor can get it also)
+    #This way no password needed.
+    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+fi
+
+# Remove all isard-hypervisor lines from known_hosts
+sed -i '/isard-hypervisor/d' /root/.ssh/known_hosts
+
 echo "Checking for isard-hypervisor ssh..."
 
 i=0
@@ -12,24 +29,9 @@ while ! nc -z isard-hypervisor 22; do
   echo "Checking for isard-hypervisor shh"
 done
 
-echo "Adding isard-hypervisor keys"
-ssh-keyscan -T 10 isard-hypervisor > /root/.ssh/known_hosts
-
-# Remove all isard-hypervisor lines from known_hosts
-sed -i '/isard-hypervisor/d' /root/.ssh/known_hosts
-
-# If no id_rsa.pub key yet, create new one
-auth_keys="/root/.ssh/id_rsa.pub"
-if [ -f "$auth_keys" ]
-then
-    echo "$auth_keys found, so not generating new ones."
+if [[ "$i" -ne '25' ]]; then
+  echo "Adding isard-hypervisor keys"
+  ssh-keyscan -T 10 isard-hypervisor > /root/.ssh/known_hosts
 else
-    echo "$auth_keys not found, generating new ones."
-    cat /dev/zero | ssh-keygen -q -N ""
-    #Copy new host key to authorized_keys (so isard-hypervisor can get it also)
-    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
-fi
-
-# Now scan for isard-hypervisor for 10 seconds (should be more than enough)
-echo "Scanning isard-hypervisor key..."
-ssh-keyscan -T 10 isard-hypervisor > /root/.ssh/known_hosts
+  echo "Assuming that there is no isard-hypervisor available"
+fi 

--- a/extras/app-devel/devel-infrastructure.yml
+++ b/extras/app-devel/devel-infrastructure.yml
@@ -1,0 +1,57 @@
+version: "3.5"
+services:
+  isard-database:
+    container_name: isard-database
+    volumes:
+      - "/opt/isard/database:/data"
+      - "/etc/localtime:/etc/localtime:ro"
+    ports:
+      - "8080:8080"        
+    networks:
+      - isard_network
+    image: rethinkdb
+    restart: unless-stopped
+
+  isard-nginx:
+    container_name: isard-nginx
+    volumes:
+      - "/opt/isard/certs/default:/etc/nginx/external"
+      - "/opt/isard/logs/nginx:/var/log/nginx"
+      - "/etc/localtime:/etc/localtime:ro"
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - isard_network
+    image: isard/nginx:1.1
+    restart: unless-stopped
+    depends_on:
+      - isard-app
+
+  isard-app:
+    container_name: isard-app
+    volumes:
+      - "sshkeys:/root/.ssh"
+      - "../../src:/isard"
+      - "/opt/isard/certs:/certs"
+      - "/opt/isard/logs:/isard/logs"
+      - "/opt/isard/database/wizard:/isard/install/wizard"
+      - "/opt/isard/backups:/isard/backups"
+      - "/opt/isard/uploads:/isard/uploads"
+    extra_hosts:
+      - "isard-engine:127.0.0.1"
+    networks:
+      - isard_network
+    image: isard/app:1.1
+    restart: unless-stopped
+    depends_on:
+      - isard-database
+      
+volumes:
+  sshkeys:
+
+networks:
+  isard_network:
+    external: false
+    name: isard_network
+

--- a/extras/remote-hyper/README.md
+++ b/extras/remote-hyper/README.md
@@ -3,3 +3,9 @@
 It brings up a remote hypervisor. Instructions can be found at documentation: 
 
 https://isardvdi.readthedocs.io/en/latest/admin/hypervisors/
+
+## Quick steps
+
+1. Mount your storage in /opt/isard.
+2. Check that exists /opt/isard/certs/default as they are used to connect to viewers securely.
+3. Bring it up: docker-compose up -d

--- a/extras/remote-hyper/docker-compose.yml
+++ b/extras/remote-hyper/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.2"
+version: "3.5"
 services:
   isard-hypervisor:
     volumes:
@@ -18,7 +18,7 @@ services:
       - "2022:22"
       - "5900-5949:5900-5949"
       - "55900-55949:55900-55949"
-    image: isard/hypervisor:1.0
+    image: isard/hypervisor:1
     privileged: true
     restart: unless-stopped
         

--- a/extras/remote-hyper/infrastructure-isard.yml
+++ b/extras/remote-hyper/infrastructure-isard.yml
@@ -1,0 +1,56 @@
+version: "3.5"
+services:
+  isard-database:
+    container_name: isard-database
+    volumes:
+      - "/opt/isard/database:/data"
+      - "/etc/localtime:/etc/localtime:ro"
+    networks:
+      - isard_network
+    image: rethinkdb
+    restart: unless-stopped
+    logging:
+        driver: none
+
+  isard-nginx:
+    container_name: isard-nginx
+    volumes:
+      - "/opt/isard/certs/default:/etc/nginx/external"
+      - "/opt/isard/logs/nginx:/var/log/nginx"
+      - "/etc/localtime:/etc/localtime:ro"
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - isard_network
+    image: isard/nginx:1
+    restart: unless-stopped
+    depends_on:
+      - isard-app
+
+  isard-app:
+    container_name: isard-app
+    volumes:
+      - "sshkeys:/root/.ssh"
+      - "/opt/isard/certs:/certs"
+      - "/opt/isard/logs:/isard/logs"
+      - "/opt/isard/database/wizard:/isard/install/wizard"
+      - "/opt/isard/backups:/isard/backups"
+      - "/opt/isard/uploads:/isard/uploads"
+      - "/etc/localtime:/etc/localtime:ro"
+    extra_hosts:
+      - "isard-engine:127.0.0.1"
+    networks:
+      - isard_network
+    image: isard/app:1
+    restart: unless-stopped
+    depends_on:
+      - isard-database
+
+volumes:
+  sshkeys:
+
+networks:
+  isard_network:
+    external: false
+    name: isard_network

--- a/src/engine/models/hyp.py
+++ b/src/engine/models/hyp.py
@@ -61,10 +61,12 @@ class hyp(object):
         # dictionary of domains
         # self.id = 0
         self.domains = []
+        port=int(port)
         if (type(port) == int) and port > 1 and port < pow(2, 16):
             self.port = port
         else:
             self.port = 22
+        log.error('El port es: '+str(self.port))
         self.try_ssh_autologin = try_ssh_autologin
         self.user = user
         self.hostname = address


### PR DESCRIPTION
Fixed bugs in infrastructure (when you have remote hypers with ports different than 22):
- Now isard-app container will keep remote hyper keys between docker restarts
- Fixed bug in engine that forbid the use of ports different than 22 to connect to hypervisors.
- Added infrastructure-isard.yml to remote-hyper extras to bring up IsardVDI without the need to bring up isard-hypervisor.