### PR TITLE
Updated grafana image, now accessible via https://.../grafana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ backups/*
 #uploads
 uploads/*
 
+#certificates
+certs/*
+
+#database
+database/*
 #docker run scripts
 run_docker_engine.py
 run_docker_webapp.py
@@ -60,3 +65,4 @@ csv/
 install/.wizard
 
 known_hosts
+grafana/

--- a/docker-compose.devel.yml
+++ b/docker-compose.devel.yml
@@ -1,23 +1,42 @@
+### Intended to be used in cloned repo in /opt/isard with command:
+### docker-compose -f docker-compose.yml -f docker-compose.devel.yml --compatibility up -d
 version: "3.5"
 services:
   isard-database:
     container_name: isard-database-devel
     ports:
-      - "8080:8080"      
+      ### Database web administration port. Warning! Has no passwd!
+      - "8080:8080"
+      ### Database driver port
       - "28015:28015"
-
+#    deploy:
+#      resources:
+#        limits:
+#          cpus: '2'
+#          memory: 512M
+#        reservations:
+#          memory: 368M
   isard-nginx:
     container_name: isard-nginx-devel
 
   isard-hypervisor:
+    ### This image overrides original to avoid starting a full hypervisor in this server
+    ### If you need to develop isard-hypervisor image remove next line:
+    image: hello-world
     container_name: isard-hypervisor-devel
     ports:
+      ### As the host could have port 22 open we map it to 2022
       - "2022:22"
         
   isard-app:
     container_name: isard-app-devel
     ports:
-      - "5000:5000"       
+      ### Web frontend runs on port 5000
+      - "5000:5000"
+      ### Engine control api
       - "5555:5555"
+    volumes:
+      ### In development we mount external source app code
+      - "/opt/isard/src:/isard"
     build:
       target: development

--- a/dockers/nginx/nginx.conf
+++ b/dockers/nginx/nginx.conf
@@ -176,6 +176,16 @@ http {
             client_max_body_size 10000M;
         }
     
+        location /grafana/ {
+            proxy_pass http://isard-grafana:3000/;
+
+            proxy_set_header    Host             $http_host;
+
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header REMOTE_ADDR $remote_addr;
+            client_max_body_size 10000M;
+        }
 
 
 	### Location of noVNC 

--- a/extras/grafana/docker-compose.yml
+++ b/extras/grafana/docker-compose.yml
@@ -13,10 +13,12 @@ services:
         mode: host
     networks:
       - isard_network
-    image: isard/grafana:1.1
+    image: isard/grafana:1.1.1
+    build:
+      context: .
     restart: unless-stopped
-    logging:
-        driver: none
+#    logging:
+#        driver: none
     #~ depends_on:
       #~ - isard-app
       

--- a/extras/grafana/grafana-defaults.ini
+++ b/extras/grafana/grafana-defaults.ini
@@ -38,7 +38,7 @@ domain = localhost
 enforce_domain = false
 
 # The full public facing url
-root_url = %(protocol)s://%(domain)s:%(http_port)s/
+root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
 
 # Log web requests
 router_logging = false


### PR DESCRIPTION
Updated grafana image. Now you can access grafana through url subpath /grafana.
Also there is a new docker-compose.devel.yml file.