### PR TITLE
Add missing openssl to isard-hypervisor

### DIFF
--- a/docker/hypervisor/Dockerfile
+++ b/docker/hypervisor/Dockerfile
@@ -49,7 +49,8 @@ RUN apk add --no-cache \
     iproute2 \
     bridge-utils \
     shadow \
-    tshark
+    tshark \
+    openssl
     
 
 RUN apk add --no-cache \


### PR DESCRIPTION
isard-hypervisor    | auto-generate-certs.sh: line 15: openssl: not found