### PR TITLE
Revert "Add missing openssl to isard-hypervisor"

### DIFF
--- a/docker/hypervisor/Dockerfile
+++ b/docker/hypervisor/Dockerfile
@@ -49,8 +49,7 @@ RUN apk add --no-cache \
     iproute2 \
     bridge-utils \
     shadow \
-    tshark \
-    openssl
+    tshark
     
 
 RUN apk add --no-cache \


### PR DESCRIPTION
Reverts isard-vdi/isard#233 as this is not working. Needs testing.