### PR TITLE
Open port, filter with firewall

### DIFF
--- a/ymls/devel/isard-db.yml.devel
+++ b/ymls/devel/isard-db.yml.devel
@@ -4,6 +4,7 @@ services:
   isard-db:
     ports:
       - "8080:8080"
+      - "28015:28015"
 networks:
   isard-network:
     external: false

--- a/ymls/isard-db.yml
+++ b/ymls/isard-db.yml
@@ -5,7 +5,7 @@ services:
     image: rethinkdb
     ports:
       - "8080:8080"
-    #   - "28015:28015"
+      - "28015:28015"
     networks:
       - isard-network
     restart: unless-stopped


### PR DESCRIPTION
This is now required for remote hypervisors to update isard-db. Firewall must be correctly set to avoid security issues.