### PR TITLE
Fix desktop creation from admin menu media of webapp

### DIFF
--- a/webapp/webapp/webapp/lib/isardSocketio.py
+++ b/webapp/webapp/webapp/lib/isardSocketio.py
@@ -1317,7 +1317,7 @@ def socketio_admin_domains_media_add(form_data):
         return
             
     create_dict=app.isardapi.f.unflatten_dict(form_data)
-    create_dict=self.parseHardwareFromIso(create_dict)
+    create_dict=parseHardwareFromIso(create_dict)
 
     create_dict['create_from_virt_install_xml']=create_dict.pop('install','')
     disk_size=create_dict.pop('disk_size','15')+'G'


### PR DESCRIPTION
"Create desktop" button of "Create desktop from media" form of admin menu media doesn't work.

```
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 766, in gevent._greenlet.Greenlet.run
  File "/usr/lib/python3.8/site-packages/socketio/server.py", line 636, in _handle_event_internal
    r = server._trigger_event(data[0], namespace, sid, *data[1:])
  File "/usr/lib/python3.8/site-packages/socketio/server.py", line 665, in _trigger_event
    return self.handlers[namespace][event](*args)
  File "/usr/lib/python3.8/site-packages/flask_socketio/__init__.py", line 223, in _handler
    return self._handle_event(handler, message, namespace, sid,
  File "/usr/lib/python3.8/site-packages/flask_socketio/__init__.py", line 591, in _handle_event
    ret = handler(*args)
  File "/isard/webapp/lib/isardSocketio.py", line 1320, in socketio_admin_domains_media_add
    create_dict=self.parseHardwareFromIso(create_dict)
NameError: name 'self' is not defined
```