### PR TITLE
Fix backing_chain_domain and backing_chain_template referenced before assignment

### DIFF
--- a/engine/engine/engine/services/lib/qcow.py
+++ b/engine/engine/engine/services/lib/qcow.py
@@ -303,6 +303,8 @@ def extract_list_backing_chain(out_cmd_qemu_img, json_format=True):
 
 def verify_output_cmds3(cmds_done, path_domain_disk, path_template_disk, id_domain):
     error = None
+    backing_chain_domain = None
+    backing_chain_template = None
 
     d = [a for a in cmds_done if a['title'] == 'create_disk_domain_from_new_template'][0]
     if len(d['err']) > 0:


### PR DESCRIPTION
```
2020/10/21 16:08:56 842 - ERROR - disk_op_isard-hypervisor: Traceback: Traceback (most recent call last):
  File "/isard/engine/services/threads/disk_operations_thread.py", line 57, in disk_operations_thread
    launch_action_create_template_disk(action,
  File "/isard/engine/services/threads/threads.py", line 249, in launch_action_create_template_disk
    error, backing_chain_domain, backing_chain_template = verify_output_cmds3(cmds_done, path_domain_disk,
  File "/isard/engine/services/lib/qcow.py", line 344, in verify_output_cmds3
    return error, backing_chain_domain, backing_chain_template
UnboundLocalError: local variable 'backing_chain_domain' referenced before assignment
```