### PR TITLE
Preserve hypervisor SSHd keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,6 +302,7 @@ services:
     - /opt/isard/certs/viewers:/etc/pki/libvirt-spice:rw
     - /opt/isard:/isard:rw
     - /opt/isard/sshkeys:/root/.ssh:rw
+    - /opt/isard/hypervisor/sshd_keys:/usr/local/etc/ssh:rw
     - /opt/isard-local/sockets:/var/run/libvirt:rw
   isard-portal:
     build:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -302,6 +302,7 @@ services:
     - /opt/isard/certs/viewers:/etc/pki/libvirt-spice:rw
     - /opt/isard:/isard:rw
     - /opt/isard/sshkeys:/root/.ssh:rw
+    - /opt/isard/hypervisor/sshd_keys:/usr/local/etc/ssh:rw
     - /opt/isard-local/sockets:/var/run/libvirt:rw
   isard-portal:
     build:

--- a/docker/hypervisor/Dockerfile
+++ b/docker/hypervisor/Dockerfile
@@ -128,12 +128,13 @@ RUN ln -s /usr/local/bin/qemu-img /usr/bin/qemu-img
 
 # SSH configuration
 RUN echo "root:isard" |chpasswd
-RUN ssh-keygen -A
 RUN sed -i \
     -e 's|[#]*PermitRootLogin prohibit-password|PermitRootLogin yes|g' \
     -e 's|[#]*PasswordAuthentication yes|PasswordAuthentication yes|g' \
     -e 's|[#]*ChallengeResponseAuthentication yes|ChallengeResponseAuthentication yes|g' \
-    -e 's|[#]*UsePAM yes|UsePAM yes|g' /etc/ssh/sshd_config
+    -e 's|[#]*UsePAM yes|UsePAM yes|g' \
+    -e 's|[#]*\(HostKey \)\(/etc/ssh/.*\)$|\1/usr/local\2|' \
+    /etc/ssh/sshd_config
     
 # Libvirt configuration and certs
 RUN useradd -ms /bin/sh qemu

--- a/docker/hypervisor/run.sh
+++ b/docker/hypervisor/run.sh
@@ -24,4 +24,5 @@ echo "Checking hypervisor..."
 echo "[1/1] basic domain start..."
 virsh create checks/domain.xml
 virsh destroy domain
+ssh-keygen -A -f /usr/local/
 /usr/sbin/sshd -D -e -f /etc/ssh/sshd_config

--- a/ymls/isard-hypervisor-vlans.yml
+++ b/ymls/isard-hypervisor-vlans.yml
@@ -14,6 +14,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - /opt/isard/certs/viewers:/etc/pki/libvirt-spice:rw
       - /opt/isard/sshkeys:/root/.ssh:rw
+      - /opt/isard/hypervisor/sshd_keys:/usr/local/etc/ssh:rw
       - /opt/isard:/isard:rw
       - /opt/isard-local/sockets/:/var/run/libvirt/
     build:

--- a/ymls/isard-hypervisor.yml
+++ b/ymls/isard-hypervisor.yml
@@ -13,6 +13,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - /opt/isard/certs/viewers:/etc/pki/libvirt-spice:rw
       - /opt/isard/sshkeys:/root/.ssh:rw
+      - /opt/isard/hypervisor/sshd_keys:/usr/local/etc/ssh:rw
       - /opt/isard:/isard:rw
       - /opt/isard-local/sockets/:/var/run/libvirt/
     build:


### PR DESCRIPTION
Fixes:
```
2020/10/24 22:32:47 841 - ERROR - try_isard-hypervisor: fail_connected_reason: ssh authentication fail when connect: Host key for server 'isard-hypervisor' does not match: got 'AAAAC3NzaC1lZDI1NTE5AAAAIHcSuxaEYXnbxMcKXi4qhDjJKr2OupGeMjdOUx58j5GH', expected 'AAAAC3NzaC1lZDI1NTE5AAAAIFY4pytnGBev53Q2fwdlrRYgR45whpCjzl5rndV7qRVQ'
```

To preserve SSHd keys used before this commit, you could run the following commands while old hypervisor container is running:
```
mkdir -p /opt/isard/hypervisor
docker cp isard-hypervisor:/etc/ssh /opt/isard/hypervisor/sshd_keys
rm /opt/isard/hypervisor/sshd_keys/moduli /opt/isard/hypervisor/sshd_keys/ssh_config /opt/isard/hypervisor/sshd_keys/sshd_config
```

See also the following comment to see instructions used to move keys from old container to new one before this changes: https://github.com/isard-vdi/isard/issues/278#issuecomment-716102809