### PR TITLE
Fix user edit form invalid warnings

### DIFF
--- a/webapp/webapp/webapp/static/admin/js/users.js
+++ b/webapp/webapp/webapp/static/admin/js/users.js
@@ -343,6 +343,7 @@ function actionsUserDetail(){
                 $('#modalEditUserForm #category option[value="'+user.category+'"]').prop("selected",true);
                 $('#modalEditUserForm #group option:selected').prop("selected", false);
                 $('#modalEditUserForm #group option[value="'+user.group+'"]').prop("selected",true);                
+                $('#modalEditUserForm').parsley().validate();
             });
             setQuotaMax('#edit-users-quota',kind='user',id=pk,disabled=false);
 	});


### PR DESCRIPTION
Reproduce reloading the page of users and editing one. Correct fields are marked as wrong.
This change run validator after refill the form.