### PR TITLE
Fix api by limiting the name length of non-persistent desktops

### DIFF
--- a/api/src/api/libv2/api_desktops_nonpersistent.py
+++ b/api/src/api/libv2/api_desktops_nonpersistent.py
@@ -108,7 +108,7 @@ class ApiDesktopsNonPersistent():
         if template == None:
             raise TemplateNotFound
         timestamp = time.strftime("%Y%m%d%H%M%S")
-        parsed_name=timestamp+'-'+_parse_string(template['name'])
+        parsed_name=(timestamp+'-'+_parse_string(template['name']))[:40]
 
         parent_disk=template['hardware']['disks'][0]['file']
         dir_disk = 'volatiles/'+category+'/'+group+'/'+user_id


### PR DESCRIPTION
Desktop edit form limits the length name of desktops to 40 characters but name cannot be edited. The form becomes unusable if desktop have a longer name. This change fixes it limiting the name length of created non-persistent desktops.