### PR TITLE
relaxed time between virtlogd and libvirt that avoids race bug sometimes

### DIFF
--- a/docker/hypervisor/run.sh
+++ b/docker/hypervisor/run.sh
@@ -3,8 +3,9 @@ sh auto-generate-certs.sh
 echo "Starting libvirt daemon..."
 chown root:kvm /dev/kvm
 /usr/sbin/virtlogd &
-/usr/sbin/libvirtd &
 sleep 2
+/usr/sbin/libvirtd &
+sleep 1
 #/usr/bin/virsh net-start default
 sh -c "/vlans-discover.sh"
 FILES=/etc/libvirt/qemu/networks/*


### PR DESCRIPTION
Just added an sleep between virtlogd and libvirtd that avoids race condition between them that fails to start hypervisor.