### PR TITLE
Force hypervisor

### DIFF
--- a/api/src/api/libv2/webapp_quotas.py
+++ b/api/src/api/libv2/webapp_quotas.py
@@ -363,13 +363,11 @@ class WebappQuotas():
         dict['graphics']=app.isardapi.get_alloweds(user_id,'graphics',pluck=['id','name','description'],order='name')
         dict['videos']=app.isardapi.get_alloweds(user_id,'videos',pluck=['id','name','description'],order='name')
         dict['boots']=app.isardapi.get_alloweds(user_id,'boots',pluck=['id','name','description'],order='name')
-        #dict['forced_hyps'].insert(0,{'id':'default','hostname':'Auto','description':'Hypervisor pool default'})
+        #dict['forced_hyp'].insert(0,{'id':'default','hostname':'Auto','description':'Hypervisor pool default'})
         dict['qos_id']=app.isardapi.get_alloweds(user_id,'qos_disk',pluck=['id','name','description'],order='name')
 
         dict['hypervisors_pools']=app.isardapi.get_alloweds(user_id,'hypervisors_pools',pluck=['id','name','description'],order='name')
-        dict['forced_hyps']=[]
-        """ if current_user.role == 'admin':
-            dict['forced_hyps']=app.adminapi.get_admin_table('hypervisors',['id','hostname','description','status']) """
+        dict['forced_hyp']=[]
 
         quota=self.get_user(user_id)
         dict={**dict, **quota}
@@ -392,5 +390,3 @@ class WebappQuotas():
         if create_dict['hardware']['qos_id'] not in [uh['id'] for uh in user_hardware['qos_id']]: create_dict['hardware']['qos_id']='unlimited'
         
         return create_dict
-        #hypervisors_pools
-        #forced_hyps

--- a/docker-compose-parts/engine.devel.yml
+++ b/docker-compose-parts/engine.devel.yml
@@ -3,3 +3,4 @@ services:
   isard-engine:
     volumes:
       - ${BUILD_ROOT_PATH}/engine/engine:/isard:rw
+    command: sleep infinity

--- a/engine/engine/engine/controllers/ui_actions.py
+++ b/engine/engine/engine/controllers/ui_actions.py
@@ -19,9 +19,9 @@ from engine.services.db import update_domain_viewer_started_values, update_table
     get_interface, update_domain_hyp_started, update_domain_hyp_stopped, get_domain_hyp_started, \
     update_domain_dict_hardware, remove_disk_template_created_list_in_domain, remove_dict_new_template_from_domain, \
     create_disk_template_created_list_in_domain, get_pool_from_domain, get_domain, insert_domain, delete_domain, \
-    update_domain_status, get_domain_force_hyp, get_hypers_in_pool, get_domain_kind, get_if_delete_after_stop, \
+    update_domain_status, get_domain_forced_hyp, get_hypers_in_pool, get_domain_kind, get_if_delete_after_stop, \
     get_dict_from_item_in_table, update_domain_dict_create_dict, update_origin_and_parents_to_new_template, \
-    get_custom_dict_from_domain, update_domain_force_hyp, get_domain_force_update, update_domain_force_update
+    get_custom_dict_from_domain, update_domain_forced_hyp, get_domain_force_update, update_domain_force_update
 from engine.services.lib.functions import exec_remote_list_of_cmds
 from engine.services.lib.qcow import create_cmd_disk_from_virtbuilder, get_host_long_operations_from_path
 from engine.services.lib.qcow import create_cmds_disk_from_base, create_cmds_delete_disk, get_path_to_disk, \
@@ -127,14 +127,14 @@ class UiActions(object):
     def start_domain_from_xml(self, xml, id_domain, pool_id='default'):
         failed = False
         if pool_id in self.manager.pools.keys():
-            force_hyp = get_domain_force_hyp(id_domain)
-            if force_hyp is not False:
+            forced_hyp = get_domain_forced_hyp(id_domain)
+            if forced_hyp is not False:
                 hyps_in_pool = get_hypers_in_pool(pool_id, only_online=False)
-                if force_hyp in hyps_in_pool:
-                    next_hyp = force_hyp
+                if forced_hyp in hyps_in_pool:
+                    next_hyp = forced_hyp
                 else:
                     log.error('force hypervisor failed for doomain {}: {}  not in hypervisors pool {}'.format(id_domain,
-                                                                                                              force_hyp,
+                                                                                                              forced_hyp,
                                                                                                               pool_id))
                     next_hyp = self.manager.pools[pool_id].get_next(domain_id=id_domain)
             else:
@@ -149,7 +149,7 @@ class UiActions(object):
 
                 if LOG_LEVEL == 'DEBUG':
                     print(f'%%%% DOMAIN: {id_domain} -- XML TO START IN HYPERVISOR: {next_hyp} %%%%')
-                    print(xml)
+                    ##print(xml)
                     update_table_field('domains',id_domain,'xml_to_start',xml)
                     print('%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%')
 
@@ -289,15 +289,15 @@ class UiActions(object):
                                                                                                                  id_domain))
                         return False
 
-                    force_hyp = get_domain_force_hyp(id_domain)
-                    if force_hyp is not False:
+                    forced_hyp = get_domain_forced_hyp(id_domain)
+                    if forced_hyp is not False:
                         hyps_in_pool = get_hypers_in_pool(pool_id, only_online=False)
-                        if force_hyp in hyps_in_pool:
-                            next_hyp = force_hyp
+                        if forced_hyp in hyps_in_pool:
+                            next_hyp = forced_hyp
                         else:
                             log.error('force hypervisor failed for doomain {}: {}  not in hypervisors pool {}'.format(
                                 id_domain,
-                                force_hyp,
+                                forced_hyp,
                                 pool_id))
                             next_hyp = self.manager.pools[pool_id].get_next(domain_id=id_domain)
                     else:
@@ -689,7 +689,7 @@ class UiActions(object):
             hyp_to_disk_create = get_host_disk_operations_from_path(path_selected, pool=pool_id, type_path='groups')
             if persistent is False:
                 print(f'desktop not persistent, forced hyp: {hyp_to_disk_create}')
-                update_domain_force_hyp(id_domain=id_new,hyp_id=hyp_to_disk_create)
+                update_domain_forced_hyp(id_domain=id_new,hyp_id=hyp_to_disk_create)
 
             cmds = create_cmds_disk_from_base(path_base=backing_file, path_new=new_file)
             log.debug('commands to disk create to launch in disk_operations: \n{}'.format('\n'.join(cmds)))

--- a/engine/engine/engine/services/db/domains.py
+++ b/engine/engine/engine/services/db/domains.py
@@ -38,14 +38,14 @@ def update_domain_force_update(id_domain, true_or_false=False):
     close_rethink_connection(r_conn)
     return results
 
-def update_domain_force_hyp(id_domain, hyp_id=None):
+def update_domain_forced_hyp(id_domain, hyp_id=None):
     r_conn = new_rethink_connection()
     rtable = r.table('domains')
 
     if hyp_id is None:
         hyp_id = ''
 
-    results = rtable.get_all(id_domain, index='id').update({'force_hyp' : hyp_id}).run(r_conn)
+    results = rtable.get_all(id_domain, index='id').update({'forced_hyp' : hyp_id}).run(r_conn)
 
     close_rethink_connection(r_conn)
     return results
@@ -496,31 +496,20 @@ def get_domain_force_update(domain_id):
         return False
 
 
-def get_domain_force_hyp(id_domain):
+def get_domain_forced_hyp(id_domain):
     r_conn = new_rethink_connection()
     rtable = r.table('domains')
 
-    results = list(rtable.get_all(id_domain, index='id').pluck('force_hyp').run(r_conn))
-
-    close_rethink_connection(r_conn)
-
-    #id_domain doesn't exist
-    if len(results) == 0:
+    try:
+        forced_hyp = rtable.get(id_domain).pluck('forced_hyp').run(r_conn)['forced_hyp']
+        close_rethink_connection(r_conn)
+    except:
         return False
-
-    #force hyp doesn't exist as key in domain dict
-    if len(results[0]) == 0:
-        return False
-
-
-    if type(results[0]['force_hyp'] is str):
-        if len(results[0]['force_hyp']) > 0:
-            return results[0]['force_hyp']
-        else:
-            return False
-    else:
-        return False
-
+    if isinstance(forced_hyp,list) and len(forced_hyp)>0:
+        ## By now, even the webapp will update it as a list, only lets
+        ## to set one forced_hyp
+        return forced_hyp[0]
+    return False
 
 def get_domain(id):
     r_conn = new_rethink_connection()

--- a/engine/engine/engine/services/evaluators/ux_eval.py
+++ b/engine/engine/engine/services/evaluators/ux_eval.py
@@ -24,7 +24,7 @@ import numpy as np
 from engine.config import GRAFANA
 from engine.controllers.eval_controller import EvalController
 from engine.services.db import update_domain_status, get_domains, get_domain_status, \
-    update_domain_force_hyp, get_domain
+    update_domain_forced_hyp, get_domain
 from engine.services.db.eval import get_eval_initial_ux, insert_eval_initial_ux
 from engine.services.evaluators.evaluator_interface import EvaluatorInterface
 from engine.services.log import logs
@@ -115,7 +115,7 @@ class UXEval(EvaluatorInterface):
             hyp = self.hyps[i]
             logs.eval.info(
                 "Calculing ux for template: {} in hypervisor {}. Domain: {}".format(template_id, hyp.id, domain_id))
-            update_domain_force_hyp(domain_id, hyp.id)
+            update_domain_forced_hyp(domain_id, hyp.id)
             threads[i] = Thread(target=self._get_stats_background, args=(domain_id, results, i, hyp))
             threads[i].start()
         for i in range(len(self.hyps)):
@@ -126,13 +126,13 @@ class UXEval(EvaluatorInterface):
             stats, et = results[i]
             self.initial_ux[template_id][hyp.id] = self._calcule_ux_domain(stats, et, hyp.cpu_power)
             domain_id = domains[i]['id']
-            update_domain_force_hyp(domain_id, '')  # Clean force_hyp
+            update_domain_forced_hyp(domain_id, '')  # Clean forced_hyp
 
     def _initial_ux_sequencial(self, template_id, domain_id):
         self.initial_ux[template_id] = {}
         for hyp in self.hyps:
             logs.eval.info("Calculing ux for template: {} in hypervisor {}".format(template_id, hyp.id))
-            update_domain_force_hyp(domain_id, hyp.id)
+            update_domain_forced_hyp(domain_id, hyp.id)
             update_domain_status('Starting', domain_id)
             stats = []
             et_mean = []
@@ -145,7 +145,7 @@ class UXEval(EvaluatorInterface):
                 et_mean.append(et)
             et = round(mean(et_mean), 2)
             self.initial_ux[template_id][hyp.id] = self._calcule_ux_domain(stats, et, hyp.cpu_power)
-        update_domain_force_hyp(domain_id, '')  # Clean force_hyp
+        update_domain_forced_hyp(domain_id, '')  # Clean forced_hyp
 
     def _get_stats_background(self, domain_id, results, i, hyp):
         # hyp.launch_eval_statistics()

--- a/webapp/webapp/webapp/lib/admin_api.py
+++ b/webapp/webapp/webapp/lib/admin_api.py
@@ -672,7 +672,14 @@ class isardAdmin():
             data2 = r.table('domains').filter(r.row['kind'].match("template")).filter(r.row['name'].match(term))    .order_by('name').pluck({'id','name','kind','group','icon','user','description'}).run(db.conn)
         return data1+data2
             
-
+    def update_forcedhyp(self,dom_id,forced_hyp):
+        try:
+            with app.app_context():
+                r.table('domains').get(dom_id).update({'forced_hyp':forced_hyp}).run(db.conn)
+            return True
+        except:
+            None
+        return False
     '''
     HYPERVISORS
     '''

--- a/webapp/webapp/webapp/lib/api.py
+++ b/webapp/webapp/webapp/lib/api.py
@@ -835,6 +835,8 @@ class isard():
                 tmpl['create_dict']['template']=tmpl['id']
                 tmpl['create_dict']['name']=tmpl['name']
                 tmpl['create_dict']['description']=tmpl['description']
+                if 'forced_hyp' in tmpl.keys():
+                    tmpl['create_dict']['forced_hyp']=tmpl['forced_hyp']
                 tmpl['create_dict']['hypervisors_pools']=tmpl['hypervisors_pools']
                         
             self.new_domain_from_tmpl(user, tmpl['create_dict'])
@@ -850,7 +852,8 @@ class isard():
         ephimeral = ephimeral_group if 'ephimeral' in ephimeral_group.keys() else  ephimeral_cat
         
         dom=app.isardapi.get_domain(create_dict['template'])
-            
+        if 'forced_hyp' not in dom.keys():
+            dom['forced_hyp']=False
         parent_disk=dom['hardware-disks'][0]['file']
 
         qos_id=create_dict.pop('qos_id') if 'qos_id' in create_dict.keys() else False
@@ -878,6 +881,7 @@ class isard():
                   'options': {'viewers':{'spice':{'fullscreen':True}}},
                   'create_dict': {'hardware':create_dict['hardware'], 
                                     'origin': create_dict['template']}, 
+                  'forced_hyp': dom['forced_hyp'],
                   'hypervisors_pools': create_dict['hypervisors_pools'],
                   'allowed': {'roles': False,
                               'categories': False,

--- a/webapp/webapp/webapp/lib/isardSocketio.py
+++ b/webapp/webapp/webapp/lib/isardSocketio.py
@@ -1051,7 +1051,22 @@ def socketio_admin_domains_update(data):
                     app.isardapi.update_table_status(current_user.id, 'domains', data,remote_addr),
                     namespace='/isard-admin/sio_admins', 
                     room='domains')
-                    
+
+@socketio.on('forcedhyp_update', namespace='/isard-admin/sio_admins')
+def socketio_admin_forcedhyp_update(data):
+    #remote_addr=request.headers['X-Forwarded-For'].split(',')[0] if 'X-Forwarded-For' in request.headers else request.remote_addr.split(',')[0]
+
+    res=app.adminapi.update_forcedhyp(data['id'], data['forced_hyp'])
+    if res:
+        data=json.dumps({'id':data['id'], 'result':True,'title':'Updated forced hypervisor','text':'Forced hypervisor has been updated...','icon':'success','type':'success'})
+    else:
+        data=json.dumps({'id':data['id'], 'result':False,'title':'Updated forced hypervisor','text':'Forced hypervisor can\'t be updated.','icon':'warning','type':'error'})
+    socketio.emit('result',
+                    data,
+                    namespace='/isard-admin/sio_admins', 
+                    room='domains')
+
+
 @socketio.on('domain_edit', namespace='/isard-admin/sio_admins')
 def socketio_admins_domain_edit(form_data):
     #~ Check if user has quota and rights to do it

--- a/webapp/webapp/webapp/lib/quotas.py
+++ b/webapp/webapp/webapp/lib/quotas.py
@@ -357,13 +357,11 @@ class QuotaLimits():
         dict['graphics']=app.isardapi.get_alloweds(user_id,'graphics',pluck=['id','name','description'],order='name')
         dict['videos']=app.isardapi.get_alloweds(user_id,'videos',pluck=['id','name','description'],order='name')
         dict['boots']=app.isardapi.get_alloweds(user_id,'boots',pluck=['id','name','description'],order='name')
-        #dict['forced_hyps'].insert(0,{'id':'default','hostname':'Auto','description':'Hypervisor pool default'})
+        #dict['forced_hyp'].insert(0,{'id':'default','hostname':'Auto','description':'Hypervisor pool default'})
         dict['qos_id']=app.isardapi.get_alloweds(user_id,'qos_disk',pluck=['id','name','description'],order='name')
 
         dict['hypervisors_pools']=app.isardapi.get_alloweds(user_id,'hypervisors_pools',pluck=['id','name','description'],order='name')
-        dict['forced_hyps']=[]
-        """ if current_user.role == 'admin':
-            dict['forced_hyps']=app.adminapi.get_admin_table('hypervisors',['id','hostname','description','status']) """
+        dict['forced_hyp']=[]
 
         quota=self.get_user(user_id)
         dict={**dict, **quota}
@@ -387,4 +385,4 @@ class QuotaLimits():
         
         return create_dict
         #hypervisors_pools
-        #forced_hyps
+        #forced_hyp

--- a/webapp/webapp/webapp/static/admin/js/domains.js
+++ b/webapp/webapp/webapp/static/admin/js/domains.js
@@ -17,7 +17,7 @@ columns= [
                 "defaultContent": '<button class="btn btn-xs btn-info" type="button"  data-placement="top" ><i class="fa fa-plus"></i></button>'
 				},
 				{ "data": "icon" },
-                { "data": "hyp_started", "width": "10px"},
+                { "data": "hyp_started", "width": "100px"},
 				{ "data": "name"},
 				{ "data": null},
 				{ "data": "status"},
@@ -120,7 +120,12 @@ $(document).ready(function() {
 							"targets": 1,
 							"render": function ( data, type, full, meta ) {
 							  return renderIcon(full);
-							}},
+                            }},
+                            {
+                            "targets": 2,
+                            "render": function ( data, type, full, meta ) {
+                                return renderHypStarted(full);
+                            }},                            
 							//~ {
 							//~ "targets": 3,
 							//~ "render": function ( data, type, full, meta ) {
@@ -145,11 +150,6 @@ $(document).ready(function() {
                               }  
                               return full.accessed;                                 
 							  //~ return moment.unix(full.accessed).toISOString("YYYY-MM-DDTHH:mm"); //moment.unix(full.accessed).fromNow();
-							}},
-                            {
-							"targets": 2,
-							"render": function ( data, type, full, meta ) {
-							  return renderHypStarted(full);
 							}}
 							]
 		} );
@@ -388,6 +388,9 @@ $(document).ready(function() {
     
     socket.on ('result', function (data) {
         var data = JSON.parse(data);
+        if(data.result){
+            $('.modal').modal('hide');
+        }        
         new PNotify({
                 title: data.title,
                 text: data.text,
@@ -409,8 +412,6 @@ $(document).ready(function() {
             $("#modalAddFromMedia").modal('hide');   
             $("#modalTemplateDesktop #modalTemplateDesktopForm")[0].reset();
             $("#modalTemplateDesktop").modal('hide');             
-            //~ $('body').removeClass('modal-open');
-            //~ $('.modal-backdrop').remove();
         }
         new PNotify({
                 title: data.title,
@@ -430,7 +431,6 @@ $(document).ready(function() {
             $("#modalEditDesktop").modal('hide');
             $("#modalBulkEditForm")[0].reset();
             $("#modalBulkEdit").modal('hide');            
-            //setHardwareDomainDefaults_viewer('#hardware-'+data.id,data);
         }
         new PNotify({
                 title: data.title,
@@ -525,28 +525,6 @@ function actionsDomainDetail(){
 
     if(url=="Desktops"){
         $('.btn-delete-template').remove()
-        //~ $('.btn-template').on('click', function () {
-            //~ if($('.quota-templates .perc').text() >=100){
-                //~ new PNotify({
-                    //~ title: "Quota for creating templates full.",
-                    //~ text: "Can't create another template, quota full.",
-                    //~ hide: true,
-                    //~ delay: 3000,
-                    //~ icon: 'fa fa-alert-sign',
-                    //~ opacity: 1,
-                    //~ type: 'error'
-                //~ });
-            //~ }else{	
-                //~ var pk=$(this).closest("[data-pk]").attr("data-pk");
-                //~ setDefaultsTemplate(pk);
-                //~ setHardwareOptions('#modalTemplateDesktop');
-                //~ setHardwareDomainDefaults('#modalTemplateDesktop',pk);
-                //~ $('#modalTemplateDesktop').modal({
-                    //~ backdrop: 'static',
-                    //~ keyboard: false
-                //~ }).modal('show');
-            //~ }
-        //~ });
 
 	$('.btn-template').on('click', function () {
 		if($('.quota-templates .perc').text() >=100){
@@ -613,7 +591,6 @@ function actionsDomainDetail(){
                 backdrop: 'static',
                 keyboard: false
             }).modal('show');
-            //delete_templates(pk);
             populate_tree_template_delete(pk);
         });
         
@@ -651,54 +628,121 @@ function actionsDomainDetail(){
         }); 
     });
     
-        $('#jumperurl-check').unbind('ifChecked').on('ifChecked', function(event){
-            if($('#jumperurl').val()==''){
+    $('#jumperurl-check').unbind('ifChecked').on('ifChecked', function(event){
+        if($('#jumperurl').val()==''){
+            pk=$('#modalJumperurlForm #id').val();
+            
+            api.ajax('/isard-admin/admin/domains/jumperurl_reset/'+pk,'GET',{}).done(function(data) {
+                $('#jumperurl').val(location.protocol + '//' + location.host+'/vw/'+data);
+            });         
+            $('#jumperurl').show();
+            $('.btn-copy-jumperurl').show();
+        }
+        }); 	
+    $('#jumperurl-check').unbind('ifUnchecked').on('ifUnchecked', function(event){
+        pk=$('#modalJumperurlForm #id').val();
+        new PNotify({
+            title: 'Confirmation Needed',
+                text: "Are you sure you want to delete direct viewer access url?",
+                hide: false,
+                opacity: 0.9,
+                confirm: {
+                    confirm: true
+                },
+                buttons: {
+                    closer: false,
+                    sticker: false
+                },
+                history: {
+                    history: false
+                },
+                addclass: 'pnotify-center'
+            }).get().on('pnotify.confirm', function() {
                 pk=$('#modalJumperurlForm #id').val();
-                
-                api.ajax('/isard-admin/admin/domains/jumperurl_reset/'+pk,'GET',{}).done(function(data) {
-                    $('#jumperurl').val(location.protocol + '//' + location.host+'/vw/'+data);
-                });         
+                api.ajax('/isard-admin/admin/domains/jumperurl_disable/'+pk,'GET',{}).done(function(data) {
+                    $('#jumperurl').val('');
+                }); 
+                $('#jumperurl').hide();
+                $('.btn-copy-jumperurl').hide();
+            }).on('pnotify.cancel', function() {
+                $('#jumperurl-check').iCheck('check');
                 $('#jumperurl').show();
                 $('.btn-copy-jumperurl').show();
+            });
+        }); 
+            
+
+    $('.btn-copy-jumperurl').on('click', function () {
+        $('#jumperurl').prop('disabled',false).select().prop('disabled',true);
+        document.execCommand("copy");
+    });
+
+
+    $('.btn-forcedhyp').on('click', function () {
+        var pk=$(this).closest("[data-pk]").attr("data-pk");
+        $("#modalForcedhypForm")[0].reset();
+        $('#modalForcedhypForm #id').val(pk);
+        $('#modalForcedhyp').modal({
+            backdrop: 'static',
+            keyboard: false
+        }).modal('show');
+        api.ajax('/isard-admin/admin/load/domains/post','POST',{'id':pk,'pluck':['id','forced_hyp']}).done(function(data) {        
+            if('forced_hyp' in data && data.forced_hyp != false && data.forced_hyp != []){
+                HypervisorsDropdown(data.forced_hyp[0]);
+                $('#modalForcedhypForm #forced_hyp').show();
+                //NOTE: With this it will fire ifChecked event, and generate new key
+                // and we don't want it now as we are just setting de initial state
+                // and don't want to reset de key again if already exists!
+                //$('#jumperurl-check').iCheck('check');
+                $('#forcedhyp-check').prop('checked',true).iCheck('update');
+            }else{
+                $('#forcedhyp-check').iCheck('update')[0].unchecked;
+                $('#modalForcedhypForm #forced_hyp').hide();
             }
-          }); 	
-        $('#jumperurl-check').unbind('ifUnchecked').on('ifUnchecked', function(event){
-            pk=$('#modalJumperurlForm #id').val();
-            new PNotify({
-                title: 'Confirmation Needed',
-                    text: "Are you sure you want to delete direct viewer access url?",
-                    hide: false,
-                    opacity: 0.9,
-                    confirm: {
-                        confirm: true
-                    },
-                    buttons: {
-                        closer: false,
-                        sticker: false
-                    },
-                    history: {
-                        history: false
-                    },
-                    addclass: 'pnotify-center'
-                }).get().on('pnotify.confirm', function() {
-                    pk=$('#modalJumperurlForm #id').val();
-                    api.ajax('/isard-admin/admin/domains/jumperurl_disable/'+pk,'GET',{}).done(function(data) {
-                        $('#jumperurl').val('');
-                    }); 
-                    $('#jumperurl').hide();
-                    $('.btn-copy-jumperurl').hide();
-                }).on('pnotify.cancel', function() {
-                    $('#jumperurl-check').iCheck('check');
-                    $('#jumperurl').show();
-                    $('.btn-copy-jumperurl').show();
-                });
-            }); 
-             
-    
-        $('.btn-copy-jumperurl').on('click', function () {
-            $('#jumperurl').prop('disabled',false).select().prop('disabled',true);
-            document.execCommand("copy");
+        }); 
+    });
+
+    $('#forcedhyp-check').unbind('ifChecked').on('ifChecked', function(event){
+        if($('#forced_hyp').val()==''){
+            pk=$('#modalForcedhypForm #id').val();  
+            api.ajax('/isard-admin/admin/load/domains/post','POST',{'id':pk,'pluck':['id','forced_hyp']}).done(function(data) {        
+                
+                if('forced_hyp' in data && data.forced_hyp != false && data.forced_hyp != []){
+                    HypervisorsDropdown(data.forced_hyp[0]);
+                }else{
+                    HypervisorsDropdown('');
+                }
+            });    
+            $('#modalForcedhypForm #forced_hyp').show();
+        }
+        }); 	
+    $('#forcedhyp-check').unbind('ifUnchecked').on('ifUnchecked', function(event){
+        pk=$('#modalForcedhypForm #id').val();
+
+        $('#modalForcedhypForm #forced_hyp').hide();
+        $("#modalForcedhypForm #forced_hyp").empty()
+    }); 
+
+    $("#modalForcedhyp #send").on('click', function(e){
+        data=$('#modalForcedhypForm').serializeObject();
+        if('forced_hyp' in data){
+            socket.emit('forcedhyp_update',{'id':data.id,'forced_hyp':[data.forced_hyp]})
+        }else{
+            socket.emit('forcedhyp_update',{'id':data.id,'forced_hyp':false})
+        }
+    });
+}
+
+function HypervisorsDropdown(selected) {
+    $("#modalForcedhypForm #forced_hyp").empty();
+    api.ajax('/isard-admin/admin/load/hypervisors/post','POST',{'pluck':['id','hostname']}).done(function(data) {
+        data.forEach(function(hypervisor){
+            $("#modalForcedhypForm #forced_hyp").append('<option value=' + hypervisor.id + '>' + hypervisor.id+' ('+hypervisor.hostname+')' + '</option>');
+            if(hypervisor.id == selected){
+                $('#modalForcedhypForm #forced_hyp option[value="'+hypervisor.id+'"]').prop("selected",true);
+            }
         });
+    });                      
 }
 
 function setDefaultsTemplate(id) {
@@ -775,9 +819,12 @@ function renderStatus(data){
 }
 
 function renderHypStarted(data){
-        if('forced_hyp' in data && data.forced_hyp!=''){return '**'+data.forced_hyp+'**';}
-        if('hyp_started' in data){ return data.hyp_started;}
-		return '';
+    res=''
+    if('forced_hyp' in data && data.forced_hyp != false && data.forced_hyp != []){
+        res='<b>F: </b>'+data.forced_hyp[0]
+    }
+    if('hyp_started' in data && data.hyp_started != ''){ res=res+'<br><b>S: </b>'+ data.hyp_started;}
+    return res
 }
 
 function renderAction(data){

--- a/webapp/webapp/webapp/static/js/desktops.js
+++ b/webapp/webapp/webapp/static/js/desktops.js
@@ -584,6 +584,7 @@ function actionsDesktopDetail(){
 function addDesktopDetailPannel ( d ) {
 		$newPanel = $template.clone();
         $newPanel.find('#derivates-d\\.id').remove();
+        $newPanel.find('.btn-forcedhyp').remove();
         $newPanel.find('.btn-xml').remove();
 		$newPanel.html(function(i, oldHtml){
 			return oldHtml.replace(/d.id/g, d.id).replace(/d.name/g, d.name);

--- a/webapp/webapp/webapp/static/js/snippets/domain_hardware.js
+++ b/webapp/webapp/webapp/static/js/snippets/domain_hardware.js
@@ -150,23 +150,11 @@
 	}
 
 	function setHardwareDomainDefaults_viewer(div_id,data){
-	    //if(data["hardware"]  != undefined){
-		//if('hardware' in data){
-
-		//}else{
-			data['hardware']=data['create_dict']['hardware']
-		//}
-		console.log(data)
+		data['hardware']=data['create_dict']['hardware']
 		$(div_id+" #vcpu").html(data.hardware.vcpus+' CPU(s)');
 		$(div_id+" #ram").html((data.hardware.memory/1048576).toFixed(2)+'GB');
-		//mem=data.hardware.memory/1048576
-		//$(div_id+" #ram").html(mem.toFixed(3)+'GB');
-
-		//$(div_id+" #ram").html(data.hardware.memory+data.hardware.memory_unit);
-		// List could not be ordered! In theory all the disks have same virtual-size
-                //~ $(div_id+" #disks").html(domain['disks_info'][0]['virtual-size']);
-	    $(div_id+" #net").html(data.hardware.interfaces);
-	    $(div_id+" #graphics").html(data.hardware.graphics);
+	    	$(div_id+" #net").html(data.hardware.interfaces);
+	    	$(div_id+" #graphics").html(data.hardware.graphics);
 		$(div_id+" #video").html(data.hardware.videos);
 		$(div_id+" #boot").html(data.hardware['boot_order']);
 		$(div_id+" #hypervisor_pool").html(data['hypervisors_pools']);
@@ -176,8 +164,6 @@
 		}else{
 			$(div_id+" #forced_hyp").closest("tr").hide(); //.closest("tr").remove();
 		}
-            //}
-			//~ }); 
 	}
 
 

--- a/webapp/webapp/webapp/static/js/snippets/domain_hotplugged.js
+++ b/webapp/webapp/webapp/static/js/snippets/domain_hotplugged.js
@@ -1,19 +1,5 @@
 var derivates_table =''
 function setDomainHotplug(id,hardware){
-    console.log(hardware)
-	//~ $("#bulk-edit-"+id).on( 'click', function () {
-            //~ $("#modalBulkEditForm")[0].reset();
-            //~ setHardwareOptions('#modalBulkEdit','disk');
-			//~ $('#modalBulkEdit').modal({
-				//~ backdrop: 'static',
-				//~ keyboard: false
-			//~ }).modal('show');
-            //~ setHardwareDomainDefaults('#modalBulkEdit', id);
-            //$('#modalAddFromBuilder #modalAdd').parsley();
-            //~ modal_bulk_edit_setdata("#modalBulkEditForm");
-	//~ });    
-        
-    //api.ajax('/isard-admin/domain/media','POST',{'pk':domain_id})
 
     hotplug_table=$("#table-hotplug-"+id).DataTable({
 			"ajax": {
@@ -26,8 +12,6 @@ function setDomainHotplug(id,hardware){
 			"language": {
 				"loadingRecords": '<i class="fa fa-spinner fa-pulse fa-3x fa-fw"></i><span class="sr-only">Loading...</span>'
 			},
-            //~ "bLengthChange": false,
-            //~ "bFilter": false,
 			"rowId": "id",
 			"deferRender": true,
 			"columns": [
@@ -36,22 +20,8 @@ function setDomainHotplug(id,hardware){
                 {'data':'size'}
                 ],
 			 "order": [[0, 'desc']],
-			 //~ "columnDefs": [ {
-							//~ "targets": 0,
-							//~ "render": function ( data, type, full, meta ) {
-                              //~ if ( type === 'display' || type === 'filter' ) {
-                                    //~ return moment.unix(full.when).fromNow();
-                              //~ }                                 
-                              //~ return data;  
-							//~ }}]
     } );
-            
-			//~ api.ajax('/domain_derivates','POST',{'pk':id}).done(function(derivates) {
-                //~ var wasted=0
-                //~ $.each(derivates,function(index,val){
-                    //~ $("#table-derivates-"+id).append('<tr><td>'+val['name']+'</td><td>'+val['kind']+'</td><td>'+val['user']+'</td></tr>');
-                //~ });  
-            //~ });
+
 
     $("#modalBulkEdit #send").on('click', function(e){
             var form = $('#modalBulkEditForm');
@@ -64,36 +34,4 @@ function setDomainHotplug(id,hardware){
         });
             
 }
-    
-//~ function modal_bulk_edit_setdata(id){
-        //~ names=''
-        //~ ids=[]
-        //~ $(id+" #ids").find('option').remove();
-        //~ if(derivates_table.rows('.active').data().length){
-            //~ $.each(derivates_table.rows('.active').data(),function(key, value){
-                //~ names+=value['name']+'\n';
-                //~ ids.push(value['id']);
-                //~ $(id+' #ids').append('<option value=' + value.id + '>' + value.name + '</option>');
-            //~ });
-            //~ var text = "You are about to these desktops:\n\n "+names
-        //~ }else{ 
-            //~ $.each(derivates_table.rows({filter: 'applied'}).data(),function(key, value){
-                //~ ids.push(value['id']);
-                //~ $(id+' #ids').append('<option value=' + value.id + '>' + value.name + '</option>');
-            //~ });
-            //~ var text = "You are about to "+derivates_table.rows({filter: 'applied'}).data().length+" desktops!\n All the desktops in list!"
-        //~ }    
-        //~ $(id+' #ids > option').attr("selected",true);
-        //~ console.log(text)
-        //~ $(id+' #afecteds').val(text);
-        
-        //~ $(id+" .btn-unselect-all").on( 'click', function () {
-            //~ $(id+' #ids > option').attr("selected",false);
-        //~ })
 
-
-        //~ $(id+" .btn-select-all").on( 'click', function () {
-            //~ $(id+' #ids > option').attr("selected",true);
-        //~ })        
-    
-//~ }

--- a/webapp/webapp/webapp/templates/admin/pages/domains_modals.html
+++ b/webapp/webapp/webapp/templates/admin/pages/domains_modals.html
@@ -289,6 +289,63 @@
    </div>
 </div>
 
+<div class="modal fade" id="modalForcedhyp" tabindex="-1" role="dialog" aria-labelledby="modalForcedHyp" aria-hidden="true">
+   <div class="modal-dialog">
+       <div class="modal-content">
+           <!-- Modal Header -->
+           <div class="modal-header" style="padding: 5px;">
+               <button type="button" class="close" data-dismiss="modal">
+                   <span aria-hidden="true">&times;</span>
+                   <span class="sr-only">Close</span>
+               </button>
+               <h4 class="modal-title" id="myModalLabel">
+                   <i class="fa fa-plus fa-1x"> </i>    Forced hypervisor <i class="fa fa-key"> </i>
+               </h4>
+           </div>
+
+           <!-- Modal Body -->
+           <div class="modal-body" style="padding: 7px;">
+
+               <form id="modalForcedhypForm" class="form-inline">
+                   <input hidden id="id" name="id"/>
+                   <div class="row">
+                       <div class="col-md-12 col-sm-12 col-xs-12">
+                             <label>Domain will be forced to start in defined hyper</label>
+                             <div class="checkbox">
+                               <label class="">
+                                 <div class="icheckbox_flat-green" style="position: relative;">
+                                     <input type="checkbox" id="forcedhyp-check" name="forcedhyp-check" class="flat"  style="position: absolute; opacity: 0;">
+                                     <ins class="iCheck-helper" style="position: absolute; top: 0%; left: 0%; display: block; width: 100%; height: 100%; margin: 0px; padding: 0px; background: rgb(255, 255, 255); border: 0px; opacity: 0;">
+                                     </ins>
+                                 </div>
+                               </label>
+                             </div> 
+                                                           
+                       </div>                                                                    
+                   </div>
+                   <div class="row">
+                     <div class="col-md-12 col-sm-12 col-xs-12">
+                        <select id="forced_hyp" name="forced_hyp" class="form-control" required>
+                        </select> 
+                     </div>
+                  </div>
+            
+           </div>
+
+           <!-- Modal Footer -->
+           <div class="modal-footer" style="padding: 5px;">
+               <ul class="nav navbar-left panel_toolbox">
+                   <li>
+                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                     <button id="send" type="button" class="btn btn-success">Update</button>
+                   </li>
+               </ul>
+           </div>
+           </form>
+       </div>
+   </div>
+</div>
+
 <div class="modal fade" id="modalBulkEdit" tabindex="-1" role="dialog" 
      aria-labelledby="modalBulkEdit" aria-hidden="true">
     <div class="modal-dialog">

--- a/webapp/webapp/webapp/templates/admin/pages/templates_detail.html
+++ b/webapp/webapp/webapp/templates/admin/pages/templates_detail.html
@@ -7,6 +7,9 @@
                      <div class="row">
                         <button class="btn btn-success btn-xs pull-right btn-template" type="button"  data-placement="top" ><i class="fa fa-cube m-right-xs"></i>Template it</button>
                      </div>
+                     <div class="row">
+                      <button class="btn btn-success btn-xs pull-right btn-forcedhyp" type="button"  data-placement="top" ><i class="fa fa-rocket m-right-xs"></i>Forced hyp</button>
+                     </div>                      
                      <!-- Needed for admin -->
                      <div class="row">
                         <button class="btn btn-danger btn-xs pull-right btn-delete-template" type="button"  data-placement="top" ><i class="fa fa-remove m-right-xs"></i>Delete</button>

--- a/webapp/webapp/webapp/templates/pages/desktops_detail.html
+++ b/webapp/webapp/webapp/templates/pages/desktops_detail.html
@@ -5,11 +5,14 @@
                   <div class="col-md-12 col-md-12 col-xs-12" id="actions-d.id" data-pk="d.id" data-name="d.name">
                         {% if(current_user.role!='user') %}
               <div class="row">
-              <button class="btn btn-success btn-xs pull-right btn-jumperurl" type="button"  data-placement="top" ><i class="fa fa-cube m-right-xs"></i>Viewer</button>
+              <button class="btn btn-success btn-xs pull-right btn-jumperurl" type="button"  data-placement="top" ><i class="fa fa-eye m-right-xs"></i>Viewer</button>
               </div>                             
 							 <div class="row">
 								<button class="btn btn-success btn-xs pull-right btn-template" type="button"  data-placement="top" ><i class="fa fa-cube m-right-xs"></i>Template it</button>
-							 </div>
+               </div>
+               <div class="row">
+               <button class="btn btn-success btn-xs pull-right btn-forcedhyp" type="button"  data-placement="top" ><i class="fa fa-rocket m-right-xs"></i>Forced hyp</button>
+              </div>                
                              <!-- Needed for admin -->
 							 <div class="row">
 								<button class="btn btn-danger btn-xs pull-right btn-delete-template" type="button"  data-placement="top" ><i class="fa fa-remove m-right-xs"></i>Delete</button>


### PR DESCRIPTION
This will let managers and administrator roles to force an hypervisor for a desktop or template. This is useful right now when you want to use shared network between hosts and you don't want to mess with infrastructure configurations: just force those desktops or the template from where are derived to an hypervisor.

The derived desktops will inherit the forced_domain defined in parent template at creation time.
The templates created from a desktop with forced_hyp will not inherit that parameter. It can be set in the newly created template if needed for next derived desktops.