### PR TITLE
fixes for tcp mode to reduce spice delay and usb passthrough

### DIFF
--- a/docker/portal/haproxy.conf
+++ b/docker/portal/haproxy.conf
@@ -24,26 +24,23 @@ global
 
   frontend  fe_proxy_squid
     bind            0.0.0.0:80
-    #no option       httpclose
-    #no option       http-server-close
-    #timeout         client 7200s
-    #option http-keep-alive
-    mode http
-    #tcp-request inspect-delay 10s
-     
-    acl letsencrypt-acl path_beg /.well-known/acme-challenge/
-    use_backend letsencrypt-backend if letsencrypt-acl
+    mode tcp
+    tcp-request inspect-delay 10s
 
-    acl is_web method GET
-    http-request redirect scheme https if is_web
-    #acl is_connect method CONNECT
-    #http-request redirect scheme https if !is_connect
-    #http-request redirect scheme https if !letsencrypt-acl
-    #use_backend be_isard-squid if { req.hdr(user-agent) -m sub GLib }
-    #use_backend be_isard-squid if is_connect
+    use_backend letsencrypt-backend if { path_beg /.well-known/acme-challenge/ }
+    use_backend redirecthttps-backend if { method GET }
 
     default_backend be_isard-squid
-         
+
+  backend redirecthttps-backend
+    mode http
+    http-request redirect scheme https if !{ ssl_fc }
+    redirect scheme https code 301 if !{ ssl_fc }
+    server localhost:443 127.0.0.1:443 check
+
+    
+    #server https-front 127.0.0.1:443 ssl verify none
+
   frontend  fe_secured
     bind            0.0.0.0:443 ssl crt /certs/
     mode            http
@@ -83,7 +80,7 @@ global
     server websockify isard-websockify:8080 check port 8080 inter 5s rise 2 fall 3 resolvers mydns init-addr none
 
   backend be_isard-squid
-    #mode tcp
+    mode tcp
     #option http-keep-alive
     option forwardfor
     option redispatch
@@ -170,4 +167,4 @@ global
         timeout             server 50000ms
 
 userlist AuthUsers
-    user admin password $6$grgQMVfwI0XSGAQl$2usaQC9LVXXXYHtSkGUf74CIGsiH8fi/K.V6DuKSq0twPkmFGP2vL/b//Ulp2I4xBEZ3eYDhUbwBPK8jpmsbo.
+    user admin password $6$fBN2a.eJs8tVVVum$kKub56o9y0IBgXpE8isywqO7Ud2SJlTEpZhJiBJQTweSTXspYyfZm2cCxx8ALE5vZaPBCDhPr/JYWNBIoRPZb1

--- a/docker/portal/haproxy.conf
+++ b/docker/portal/haproxy.conf
@@ -26,20 +26,16 @@ global
     bind            0.0.0.0:80
     mode tcp
     tcp-request inspect-delay 10s
-
+    tcp-request content accept if { ssl_fc }
     use_backend letsencrypt-backend if { path_beg /.well-known/acme-challenge/ }
-    use_backend redirecthttps-backend if { method GET }
-
+    use_backend redirecthttps-backend if !{ method CONNECT }
+    tcp-request content accept if !HTTP
     default_backend be_isard-squid
 
   backend redirecthttps-backend
     mode http
     http-request redirect scheme https if !{ ssl_fc }
-    redirect scheme https code 301 if !{ ssl_fc }
     server localhost:443 127.0.0.1:443 check
-
-    
-    #server https-front 127.0.0.1:443 ssl verify none
 
   frontend  fe_secured
     bind            0.0.0.0:443 ssl crt /certs/
@@ -71,7 +67,6 @@ global
 
     use_backend be_isard-webapp if { path_beg /socket.io }
     use_backend be_isard-webapp if { path_beg /isard-admin } or { path_beg /isard-admin/ }
-    #use_backend be_isard-webapp if { path_beg /admin } or { path_beg /admin/ }
 
     default_backend         be_isard-static
 


### PR DESCRIPTION
This new config solves the spice delay and usb passthrough problems we were having.