### PR TITLE
Fix hypervisor shared network dhcp range

### DIFF
--- a/docker/hypervisor/networks/shared.xml
+++ b/docker/hypervisor/networks/shared.xml
@@ -6,7 +6,7 @@
   <mac address='52:54:00:47:b3:70'/>
   <ip address='192.168.124.1' netmask='255.255.252.0'>
     <dhcp>
-      <range start='192.168.127.33' end='192.168.127.254'/>
+      <range start='192.168.124.33' end='192.168.127.254'/>
     </dhcp>
   </ip>
 </network>


### PR DESCRIPTION
Without this change we are leaving 799 hosts outside DHCP range and only 222 host for the DHCP range.
With this change we are leaving 32 hosts outside DHCP range and 990 hosts for
the DHCP range.

See also: https://github.com/isard-vdi/isard/pull/350#pullrequestreview-555299684