### PR TITLE
fixed bug when restoring tables from backup

### DIFF
--- a/webapp/webapp/webapp/admin/views/AdminViews.py
+++ b/webapp/webapp/webapp/admin/views/AdminViews.py
@@ -250,6 +250,7 @@ def admin_backup_detailinfo():
     global backup_data,backup_db
     if request.method == 'POST':
         table=request.get_json(force=True)['table']
+        if table=='': return json.dumps({}), 200, {'ContentType':'application/json'}
         new_db=app.adminapi.check_new_values(table,backup_db[table])
         return json.dumps(new_db), 200, {'ContentType':'application/json'}
     return json.dumps('Method not allowed.'), 500, {'ContentType':'application/json'}

--- a/webapp/webapp/webapp/static/admin/js/config.js
+++ b/webapp/webapp/webapp/static/admin/js/config.js
@@ -230,7 +230,7 @@ $(document).ready(function() {
 						//~ },
 						columns: [
 							{ "data": "id", "width": "88px"},
-							{ "data": "description", "width": "88px"},
+							{ "data": "description", "width": "88px", "defaultContent": ""},
 							{
 							"className":      'actions-control',
 							"orderable":      false,


### PR DESCRIPTION
It didn't populate correctly tables where description was missing. Also fixed bug when selecting none ('Choose...')