### PR TITLE
fixed db path

### DIFF
--- a/docker/portal/haproxy.conf
+++ b/docker/portal/haproxy.conf
@@ -91,8 +91,8 @@ global
   backend be_isard-db
    acl authorized http_auth(AuthUsers)
    http-request auth realm AuthUsers unless authorized
-
-   http-request replace-path /debug/metrics-db/(.*) /\1    
+   http-request redirect scheme http drop-query append-slash if { path -m str /debug/db }
+   http-request replace-path /debug/db/(.*) /\1    
    http-request del-header Authorization 
    server metrics-db "${RETHINKDB_HOST}":8080 maxconn 10 check port 8080 inter 5s rise 2 fall 3  resolvers mydns init-addr none
    server isard-static isard-static backup


### PR DESCRIPTION
The db access withouth trailing slash was not working, even with trailing slash. This allows access without trailing slash (/debug/db)