### PR TITLE
fixed alloweds

### DIFF
--- a/docker/hypervisor/run.sh
+++ b/docker/hypervisor/run.sh
@@ -1,4 +1,4 @@
-rm /run/libvirt/qemu/_*
+rm -rf /run/libvirt/*
 echo "Generating selfsigned certs for spice client..."
 sh auto-generate-certs.sh
 echo "Starting libvirt daemon..."

--- a/webapp/webapp/share_none.py
+++ b/webapp/webapp/share_none.py
@@ -1,0 +1,13 @@
+import requests
+from rethinkdb import r, ReqlTimeoutError
+r.connect('isard-db', 28015).repl()
+
+def activate_shares():
+        try:
+            r.db('isard').table('config').get(1).update({'shares':{'templates': False, 'isos':False}}).run()
+            print("Shares between categories deactivated")
+        except Exception as e:
+            print("Error activating shares.\n"+str(e))
+
+activate_shares()
+

--- a/webapp/webapp/webapp/lib/isardSocketio.py
+++ b/webapp/webapp/webapp/lib/isardSocketio.py
@@ -103,7 +103,7 @@ class DomainsThread(threading.Thread):
             except Exception as e:
                 print('DomainsThread internal error: \n'+traceback.format_exc())
                 log.error('DomainsThread internal error: \n'+traceback.format_exc())
-               
+
         print('DomainsThread ENDED!!!!!!!')
         log.error('DomainsThread ENDED!!!!!!!')      
 
@@ -1450,8 +1450,8 @@ def socketio_admin_resources_update(data):
 ## Alloweds
 @socketio.on('allowed_update', namespace='/isard-admin/sio_admins')
 def socketio_admin_allowed_update(data):
-    if current_user.role == 'admin' or current_user.role == 'manager': 
-        res = app.adminapi.update_table_dict(data['table'], data['id'],{'allowed':data['allowed']})
+    if current_user.role == 'admin' or current_user.role == 'manager':
+        res = app.adminapi.update_table_dict(data['table'], data['id'],{'allowed':data['allowed']}, keep_missing_fields=True)
         if res:
             data=json.dumps({'result':True,'title':'Update permissions','text':'Permissions updated for '+data['id'],'icon':'success','type':'success'})
         else:
@@ -1463,7 +1463,7 @@ def socketio_admin_allowed_update(data):
 
 @socketio.on('allowed_update', namespace='/isard-admin/sio_users')
 def socketio_allowed_update(data):
-    res = app.adminapi.update_table_dict(data['table'], data['id'],{'allowed':data['allowed']})
+    res = app.adminapi.update_table_dict(data['table'], data['id'],{'allowed':data['allowed']}, keep_missing_fields=True)
     if res:
         info=json.dumps({'result':data,'title':'Update permissions','text':'Permissions updated for '+data['id'],'icon':'success','type':'success'})
     else:
@@ -1473,9 +1473,6 @@ def socketio_allowed_update(data):
                     namespace='/isard-admin/sio_users', 
                     room='user_'+current_user.id)
 
-                
-                
-                    
 ## Admin namespace
 @socketio.on('connect', namespace='/isard-admin/sio_admins')
 def socketio_admins_connect():

--- a/webapp/webapp/webapp/static/admin/js/domains.js
+++ b/webapp/webapp/webapp/static/admin/js/domains.js
@@ -44,7 +44,6 @@ $(document).ready(function() {
         $('#allowed-title').html('')
         $('#alloweds_panel').css('display','block');
         setAlloweds_add('#alloweds-block');
-        console.log($('meta[id=user_data]').attr('data-role'))
         if ($('meta[id=user_data]').attr('data-role') == 'manager'){
             $('#categories_pannel').hide();
             $('#roles_pannel').hide();
@@ -60,7 +59,6 @@ $(document).ready(function() {
                 if (template !=''){
                     data=$('#modalAdd').serializeObject();
                     data=replaceAlloweds_arrays('#modalAddDesktop #alloweds-block',data)
-                    console.log(data)
                     socket.emit('domain_add',data)
                 }else{
                     $('#modal_add_desktops').closest('.x_panel').addClass('datatables-error');
@@ -91,7 +89,7 @@ $(document).ready(function() {
             modal_add_desktop_datatables();
         }
     });
-    
+
     $("#modalTemplateDesktop #send").on('click', function(e){
             var form = $('#modalTemplateDesktopForm');
 
@@ -410,9 +408,9 @@ $(document).ready(function() {
     socket.on('connect_error', function(data) {
       connection_lost();
     });
-    
+
     startClientViewerSocket(socket);
-    
+
     socket.on('user_quota', function(data) {
         console.log('Quota update')
         var data = JSON.parse(data);
@@ -424,7 +422,7 @@ $(document).ready(function() {
         dtUpdateInsert(domains_table,data,false);
         setDomainDetailButtonsStatus(data.id, data.status);
     });
-    
+
     socket.on(kind+'_delete', function(data){
         var data = JSON.parse(data);
         var row = domains_table.row('#'+data.id).remove().draw();
@@ -438,7 +436,7 @@ $(document).ready(function() {
                 type: 'success'
         });
     });
-    
+
     socket.on ('result', function (data) {
         var data = JSON.parse(data);
         if(data.result){
@@ -456,7 +454,6 @@ $(document).ready(function() {
     });
 
     socket.on('add_form_result', function (data) {
-        console.log('received result')
         var data = JSON.parse(data);
         if(data.result){
             $("#modalAddFromBuilder #modalAdd")[0].reset();
@@ -477,9 +474,7 @@ $(document).ready(function() {
         });
     });
 
-    
     socket.on('adds_form_result', function (data) {
-        console.log('received multiple add result')
         var data = JSON.parse(data);
         if(data.result){
             $("#modalAddDesktop #modalAdd")[0].reset();

--- a/webapp/webapp/webapp/static/js/media.js
+++ b/webapp/webapp/webapp/static/js/media.js
@@ -230,18 +230,9 @@ $(document).ready(function() {
                 }
             break;
         };
-
-
-        //~ $('btn-abort').on('click', function () {
-
-        //~ });
         
-        //~ $('btn-delete').on('click', function () {
+    });
 
-        //~ });
-    
-    });    
-    
     $("#modalAddMedia #send").on('click', function(e){
             var form = $('#modalAddMediaForm');
 
@@ -252,12 +243,7 @@ $(document).ready(function() {
                 data=replaceAlloweds_arrays('#modalAddMediaForm #alloweds-add',data)
                 socket.emit('media_add',data)
             }
-            
-
         });
-
-
-
 
 
     // SocketIO
@@ -271,8 +257,7 @@ $(document).ready(function() {
     socket.on('connect_error', function(data) {
       connection_lost();
     });
-    
-     
+
     socket.on('user_quota', function(data) {
         var data = JSON.parse(data);
         drawUserQuota(data);
@@ -288,7 +273,6 @@ $(document).ready(function() {
         //~ $('.progress .progress-bar').progressbar();
     });
 
-    
     socket.on('media_delete', function(data){
         //~ console.log('delete')
         var data = JSON.parse(data);
@@ -352,32 +336,29 @@ $(document).ready(function() {
                 type: data.type
         });
     });
-
-    
  } );
 
-
 function renderProgress(data){ 
-            perc = data.progress.received_percent
-            return data.progress.total+' - '+data.progress.speed_download_average+'/s - '+data.progress.time_left+'<div class="progress"> \
-                  <div id="pbid_'+data.id+'" class="progress-bar" role="progressbar" aria-valuenow="'+perc+'" \
-                  aria-valuemin="0" aria-valuemax="100" style="width:'+perc+'%"> \
-                    '+perc+'%  \
-                  </div> \
-                </<div> '
+    perc = data.progress.received_percent
+    return data.progress.total+' - '+data.progress.speed_download_average+'/s - '+data.progress.time_left+'<div class="progress"> \
+            <div id="pbid_'+data.id+'" class="progress-bar" role="progressbar" aria-valuenow="'+perc+'" \
+            aria-valuemin="0" aria-valuemax="100" style="width:'+perc+'%"> \
+            '+perc+'%  \
+            </div> \
+        </<div> '
 }
 
 function renderName(data){
-		return '<div class="block_content" > \
-      			<h2 class="title" style="height: 4px; margin-top: 0px;"> \
-                <a>'+data.name+'</a> \
-                </h2> \
-      			<p class="excerpt" >'+data.description+'</p> \
-           		</div>'
+    return '<div class="block_content" > \
+            <h2 class="title" style="height: 4px; margin-top: 0px;"> \
+            <a>'+data.name+'</a> \
+            </h2> \
+            <p class="excerpt" >'+data.description+'</p> \
+            </div>'
 }
 
 function renderIcon(data){
-		return '<span class="xe-icon" data-pk="'+data.id+'">'+icon(data.icon)+'</span>'
+    return '<span class="xe-icon" data-pk="'+data.id+'">'+icon(data.icon)+'</span>'
 }
 
 function icon(name){
@@ -387,11 +368,8 @@ function icon(name){
            return "<i class='fa fa-"+name+" fa-2x '></i>";
         }else{
             return "<span class='fl-"+name+" fa-2x'></span>";
-		}       
+		}
 }
-
-
-
 
 
 // MODAL install FUNCTIONS
@@ -412,8 +390,7 @@ function initialize_modal_all_install_events(){
             $('#modalInstall #datatables-install-error-status').empty().removeClass('my-error');   //.html('Selected: '+rdata['name']+'')
             $('#modalInstall #install').val(rdata['id']);
         }
-    } );	
-        	
+    } );
 }
 
 
@@ -465,52 +442,22 @@ function modal_add_install_datatables(){
             }
         } );
     } );
-    
+
     $("#modalAddFromMedia #send").on('click', function(e){
             var form = $('#modalAddFromMedia #modalAdd');
             form.parsley().validate();
             
             if (form.parsley().isValid()){
                 install=$('#modalAddFromMedia #install').val();
-                //~ console.log('install:'+install+'XXX')
-                
-                //~ if (install !=''){console.log('install not empty')}else{console.log('install empty')}
-                
                 if (install !=''){
                     data=$('#modalAddFromMedia  #modalAdd').serializeObject();
                     socket.emit('domain_media_add',data)
                 }else{                
-                    //~ console.log('OK!!')
                         $('#modal_add_install').closest('.x_panel').addClass('datatables-error');
                         $('#modalAddFromMedia #datatables-install-error-status').html('No OS template selected').addClass('my-error');                    
                 }
-            }        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-            //~ var form = $('#modalAddFromMedia #modalAdd');
-
-            //~ form.parsley().validate();
-
-            //~ if (form.parsley().isValid()){
-                //~ data=$('#modalAddFromMedia #modalAdd').serializeObject();
-                //~ data=replaceAlloweds_arrays(data)
-                //~ console.log(data)
-                //~ socket.emit('domain_media_add',data)
-            //~ }
-            
-
-        });    
-
+            }
+        });
 }
 
 

--- a/webapp/webapp/webapp/static/js/snippets/alloweds.js
+++ b/webapp/webapp/webapp/static/js/snippets/alloweds.js
@@ -25,10 +25,15 @@
 	}
 
 	function replaceAlloweds_arrays(parent_id,data){
-        data['allowed']={'roles':    parseAllowed(parent_id,'a-roles'),
-                        'categories':parseAllowed(parent_id,'a-categories'),
-                        'groups':parseAllowed(parent_id,'a-groups'),
-                        'users':parseAllowed(parent_id,'a-users')}
+        if(!$(parent_id+' #a-roles-cb').length ){
+            data['allowed']={   'groups':parseAllowed(parent_id,'a-groups'),
+                                'users':parseAllowed(parent_id,'a-users')}
+        }else{
+            data['allowed']={'roles':    parseAllowed(parent_id,'a-roles'),
+                            'categories':parseAllowed(parent_id,'a-categories'),
+                            'groups':parseAllowed(parent_id,'a-groups'),
+                            'users':parseAllowed(parent_id,'a-users')}
+        }
         delete data['a-roles'];
         delete data['a-categories'];
         delete data['a-groups'];
@@ -39,10 +44,9 @@
         delete data['a-users-cb'];        
         return data
     }
-        
+
     function parseAllowed(parent_id,id){
         d=$(parent_id+" #"+id).select2("val")
-        //~ console.log(d)
         if(d==null){
             if($(parent_id+' #'+id+'-cb').iCheck('update')[0].checked){
                 return [];
@@ -53,8 +57,6 @@
     }
 	
 
-
- 	
 	function setAlloweds_add(parentid){
 		ids=['a-roles','a-categories','a-groups','a-users']
 		 $.each(ids,function(idx,id) 
@@ -67,7 +69,6 @@
                   $(parentid+" #"+id).empty().trigger('change')
 			 });
 			 $(parentid+" #"+id).attr('disabled',true);
-             //~ console.log(id)
             if( id.replace('a-','') == 'groups'){
                 $(parentid+" #"+id).select2({
                     placeholder: "Empty applies to all. Type at least 2 letters to search.",
@@ -86,7 +87,6 @@
                             });
                         },
                         processResults: function (data) {
-                            console.log(data)
                             return {
                                 results: $.map(data, function (item, i) {
                                     return {
@@ -97,7 +97,7 @@
                             };
                         }
                     },
-                });	                
+                });
             }else{
                 $(parentid+" #"+id).select2({
                     placeholder: "Empty applies to all. Type at least 2 letters to search.",
@@ -155,7 +155,6 @@
                     $('#modalAllowedsForm #alloweds-add #a-'+key+'-cb').iCheck('check');
                     value.forEach(function(data)
                     {  
-                        //console.log(data)
                         if('parent_category' in data){                                
                             var newOption = new Option('['+data['parent_category']+'] '+data.name, data.id, true, true);
                         }else{
@@ -169,8 +168,6 @@
         });
 
 
-
-            
         socket.off('allowed_result');
         socket.on('allowed_result', function (data) {
             var data = JSON.parse(data);

--- a/webapp/webapp/webapp/templates/snippets/alloweds_add.html
+++ b/webapp/webapp/webapp/templates/snippets/alloweds_add.html
@@ -11,6 +11,7 @@
         <div class="clearfix"></div>
       </div>
       <div id="alloweds_panel" class="x_content" style="display: none;">
+                    {% if current_user.role == 'admin' %}
                         <div class="row" id="roles_pannel">
                             <div class="col-md-3 col-xs-12">
                               <label class="control-label" for="a-roles-cb">
@@ -48,6 +49,7 @@
                                 </select>
                             </div>
                         </div>
+                        {% endif %}
 
                         <div class="row">
                             <div class="col-md-3 col-xs-12">

--- a/webapp/webapp/webapp/views/DesktopViews.py
+++ b/webapp/webapp/webapp/views/DesktopViews.py
@@ -78,24 +78,6 @@ def domains_update():
 def domain_alloweds_select2():
     allowed=request.get_json(force=True)['allowed']
     return json.dumps(app.isardapi.get_alloweds_select2(allowed))
-       
-
-# We should remove this
-# Not used?
-@app.route('/isard-admin/desktops/filterTemplate/<kind>', methods=['GET'])
-@app.route('/isard-admin/desktops/filterTemplate/<kind>/category/<category>', methods=['GET'])
-@app.route('/isard-admin/desktops/filterTemplate/<kind>/group/<group>', methods=['GET'])
-@app.route('/isard-admin/desktops/filterTemplate/<kind>/user/<user>', methods=['GET'])
-@login_required
-def filterTemplate(kind,category=False,group=False,user=False):
-    custom_filter={}
-    if category:
-        custom_filter['category']=category
-    if group:
-        custom_filter['group']=group
-    if user:
-        custom_filter['user']=user
-    return Response(json.dumps(app.isardapi.get_alloweds_domains(current_user.id,kind, custom_filter)), mimetype='application/json')
 
 # Get all templates allowed for current_user
 @app.route('/isard-admin/desktops/getAllTemplates', methods=['GET'])
@@ -104,7 +86,7 @@ def getAllTemplates():
     templates = app.isardapi.get_all_alloweds_domains(current_user.id)
     templates = [t for t in templates if t['status']=='Stopped']
     if current_user.role != "admin":
-        templates = [t for t in templates if t['category'] == current_user.category or app.shares_templates == True]
+        templates = [t for t in templates if t['category'] == current_user.category or t['role'] == 'admin' or app.shares_templates == True]
     return Response(json.dumps(templates), mimetype='application/json')
 
 # Gets users, categories and groups


### PR DESCRIPTION
This fix will allow to keep the default 'non-shared' templates between categories while still allowing categories to get templates shared by the admin.
Also disabled the roles and categories fields in alloweds sharing for non admins. The idea behind is that non admins can organize their users by using the groups and using them to share templates within their category.
If an admin wants to share a template from a category to another category then he has to create a desktop from that template, convert it to template and share it as he wants.