### PR TITLE
We missed the recursive and was not really working...

### DIFF
--- a/docker/hypervisor/run.sh
+++ b/docker/hypervisor/run.sh
@@ -1,4 +1,4 @@
-rm /run/libvirt/*
+rm -rf /run/libvirt/*
 echo "Generating selfsigned certs for spice client..."
 sh auto-generate-certs.sh
 echo "Starting libvirt daemon..."


### PR DESCRIPTION
We missed recursive ;-)

I've also checked that we can't just remove /run/libvirt because on container restart complains about processes already using that folder. So this seems the best option to handle restarts with vms already running inside.