### PR TITLE
This fixes the vlans by moving the host interface inside isard-hyperv…

### DIFF
--- a/docker-compose-parts/hypervisor-vlans.yml
+++ b/docker-compose-parts/hypervisor-vlans.yml
@@ -1,14 +1,20 @@
 version: "3.5"
 services:
   isard-hypervisor:
-    networks:
-      - isard-network
-      - internet-vms
-networks:
-  internet-vms:
-    driver: macvlan
-    driver_opts:
-      parent: ${HYPERVISOR_HOST_TRUNK_INTERFACE}
-    ipam:
-      config:
-        - subnet: 172.30.0.0/16
+    environment:
+      - pipework_cmd=--direct-phys ${HYPERVISOR_HOST_TRUNK_INTERFACE} -i vlans isard-hypervisor 0/0
+
+  pipework:
+    image: dreamcat4/pipework
+    container_name: isard-pipework
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/docker.sock
+    privileged: true
+    pid: host # THIS REQUIRES COMPOSE v1.3.0 & DOCKER v1.6.0
+    network_mode: host
+    environment:
+      - run_mode=batch,daemon
+      - host_routes=true
+      - route_add_delay=1
+   

--- a/docker/hypervisor/run.sh
+++ b/docker/hypervisor/run.sh
@@ -1,4 +1,4 @@
-rm /run/libvirt/*
+rm -rf /run/libvirt/*
 echo "Generating selfsigned certs for spice client..."
 sh auto-generate-certs.sh
 echo "Starting libvirt daemon..."

--- a/docker/hypervisor/vlans-add.sh
+++ b/docker/hypervisor/vlans-add.sh
@@ -13,7 +13,7 @@ VLANS=$(echo $VLANS | tr "," " ")
 for VLAN in $VLANS
 do
        echo "Creating vlan interface v$VLAN..."
-       ip link add name v$VLAN link eth1 type vlan id $VLAN
+       ip link add name v$VLAN link vlans type vlan id $VLAN
        ip link set v$VLAN up
        echo "Creating bridge br-$VLAN"
        ip link add name br-$VLAN type bridge

--- a/docker/hypervisor/vlans-discover.sh
+++ b/docker/hypervisor/vlans-discover.sh
@@ -5,13 +5,13 @@ if [ -z "$HYPERVISOR_HOST_TRUNK_INTERFACE" ]; then
 	exit 0
 elif [ ! -z "$HYPERVISOR_HOST_TRUNK_INTERFACE" ] & [ -z "$HYPERVISOR_STATIC_VLANS" ]; then
     echo "VLANS enabled for DYNAMIC discovery."
-	eth=$(ip link | awk -F: '$0 ~ "eth1@"{print $2;getline}')
+	eth=$(ip link | awk -F: '$0 ~ "vlans@"{print $2;getline}')
 	if [ -z $eth ]; then
 		echo "Trunk interface not found. Not starting vlan autodiscovery."
 		exit 0
 	fi
 	echo "Wait, scanning trunk interface for VLANS for 260 seconds..."
-	tshark -a duration:260 -i eth1 -Y "vlan" -x -V 2>&1 |grep -o " = ID: .*" |awk '{ print $NF }'  > out
+	tshark -a duration:260 -i vlans -Y "vlan" -x -V 2>&1 |grep -o " = ID: .*" |awk '{ print $NF }'  > out
 	cat out | sort -u > /root/.ssh/vlans
 	rm out
 elif [ ! -z "$HYPERVISOR_HOST_TRUNK_INTERFACE" ] & [ ! -z "$HYPERVISOR_STATIC_VLANS" ]; then
@@ -26,7 +26,7 @@ for VLAN in $VLANS
 do
 	echo "SETTING VLAN: $VLAN"
 	echo "Creating vlan interface v$VLAN..."
-	ip link add name v$VLAN link eth1 type vlan id $VLAN
+	ip link add name v$VLAN link vlans type vlan id $VLAN
 	ip link set v$VLAN up
 	echo "Creating bridge br-$VLAN"
 	ip link add name br-$VLAN type bridge

--- a/isardvdi.cfg.example
+++ b/isardvdi.cfg.example
@@ -61,11 +61,22 @@ DOCKER_IMAGE_TAG=v2.0.0-rc1
 LOG_LEVEL=INFO
 
 # HYPERVISOR
+## VLAN mapping
+## You need to map a trunk 802.1q interface with your desired vlans
+## that will be taken from the host and inserted in hypervisor.
+## (I mean you will miss this interface from the host!)
+##
+## Requirements: pipework script, arping and wget
+## - pipework: wget -O /usr/local/bin/pipework https://raw.githubusercontent.com/jpetazzo/pipework/master/pipework && sudo chmod +x /usr/local/bin/pipework
+## - packages: apt install arping wget -y
+##
 ## Uncomment to map host interface name inside hypervisor container.
 ## If static vlans are commented then hypervisor will initiate an 
 ## auto-discovery process. The discovery process will last for 260
 ## seconds and this will delay the hypervisor from being available.
 ## So it is recommended to set also the static vlans.
+## Note: It will create VlanXXX automatically on webapp. You need to
+##       assign who is allowed to use this VlanXXX interfaces.
 #HYPERVISOR_HOST_TRUNK_INTERFACE=
 
 ## This environment variable depends on previous one. When setting


### PR DESCRIPTION
The vlans feature has been redone by using pipework and now moving the selected host trunk interface inside isard-hypervisor container. The scripts to set the vlans work as before.

Note: The host interface will be moved to isard-hypervisor network namespace. This means it will disappear completely from the host.