### PR TITLE
Optional adding custom networks

### DIFF
--- a/docker-compose-parts/hypervisor.yml
+++ b/docker-compose-parts/hypervisor.yml
@@ -17,5 +17,6 @@ services:
       - /opt/isard/hypervisor/sshd_keys:/usr/local/etc/ssh:rw
       - /opt/isard:/isard:rw
       - /opt/isard-local/sockets/:/var/run/libvirt/
+      - /opt/isard/hypervisor/networks:/networks
     env_file:
       - .env

--- a/docker/hypervisor/run.sh
+++ b/docker/hypervisor/run.sh
@@ -6,6 +6,8 @@ sh auto-generate-certs.sh
 echo "Setting wireguard.xml network for $WG_HYPER_GUESTNET"
 python3 wireguard.py
 
+cp /networks/* /etc/libvirt/qemu/networks/
+
 #ip r a $WG_USERS_NET via ${WG_HYPER_NET_WG_PEER}
 
 env > /tmp/env


### PR DESCRIPTION
With this patch users can add their custom hypervisor networks at /opt/isard/networks in xml and it will be loaded and started at hypervisor restart.