### PR TITLE
Fix docker-compose depends_on contains an invalid type issue

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,10 @@ docker-build:
     - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
   script:
     - apk add bash git docker-compose
+    # Use docker compose < 1.27 to avoid depends_on issue
+    # https://github.com/isard-vdi/isard/issues/390
+    - apk add py3-pip
+    - pip install docker-compose~=1.26.0
     - cp isardvdi.cfg.example isardvdi.cfg
     - echo "DOCKER_IMAGE_PREFIX=${CI_REGISTRY_IMAGE}/" >> isardvdi.cfg
     - echo "DOCKER_IMAGE_TAG=$CI_COMMIT_REF_SLUG" >> isardvdi.cfg


### PR DESCRIPTION
```
$ wget https://isardvdi.com/docker-compose.yml
$ docker-compose -v
docker-compose version 1.25.0, build unknown
$ docker-compose up
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.isard-engine.depends_on contains an invalid type, it should be an array
```